### PR TITLE
Change @angular dependencies to peer dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ Install this library :
 ## Angular compatibility
 
 You have to use the `ng2-discovery` version that is compatible with your version of [Angular](https://github.com/angular/angular).
+
+You need `@angular` dependencies in your application to use this library.
+
 Here is the compatibility matrix:
 
 | ng2-discovery | Angular |
 | ------------- | ------- |
 | ^1            | <=4     |
-| ^2            | ^6      |
+| ^2            | >=6      |
 
 See compatible versions on [npm semver calculator](https://semver.npmjs.com).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vidal-community/ng2-discovery",
-  "version": "2.0.1",
+  "version": "2.0.2-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -222,6 +222,7 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-6.1.7.tgz",
       "integrity": "sha512-bjX3VEVEh5scGDDmxEKPzYI8DWUbqOFA34aYDY2cHPnDkLM0I7pEtO44qb72FSbWwXn77sYlby/dx2gtRayOOA==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -260,6 +261,7 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-6.1.7.tgz",
       "integrity": "sha512-zFK2xM0hqR2ZWIfUsn+06jg+0K5PolzTxPjfUtVQDCZo+JHHKTVHEwtfORUaMTMfH9EqKrvfB3t6fCwK0523ag==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -422,6 +424,7 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-6.1.7.tgz",
       "integrity": "sha512-3MtS8EQy+saNcImDWghphOr/h3l5CpFnZW6aaHiL8T5CpTBNdB86uEmAwtiNQkJ0UeO+cztF1zNCzhm9R93/3w==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -430,6 +433,7 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-6.1.7.tgz",
       "integrity": "sha512-McCElnn6Abr+HAjwxa1ldvIMs101TT0NGq8EHXLyF9QcKG24dU7425+MdLuW0OrtgBql2+RjlqnSiKuxDQHxJA==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -438,6 +442,7 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/@angular/http/-/http-6.1.7.tgz",
       "integrity": "sha512-N0wXHpEL/CsNM4l44Z+dU51Y994mBEHjt9yb0SeKf02mdrsTJK+cEvfZ0JkVDjGddqdWHvWFn3zSmkR79qLrSQ==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -452,6 +457,7 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-6.1.7.tgz",
       "integrity": "sha512-YOYg944aefCWElJhnma8X+3wJDb6nHf6aBAVN+YPg0bUplEFacR4y6PeM9QR8vjh5Y0kbGG9ZPGDT/WwP2t4sQ==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -460,6 +466,7 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-6.1.7.tgz",
       "integrity": "sha512-sSF7n4SpwPiP1fMwocu/RUegpp/45jHK/+r9biXUXUBD12zO5QMcLHU393sjoNi7e6+meuXEH0pnWa66dTznjw==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -479,6 +486,7 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-6.1.7.tgz",
       "integrity": "sha512-YaOTq2icKAd9FDls2qo2Qp8FrmLGke3eA+bZ3FvOhFydxyUAvlU96N9Y9Gb05tXTtBaQNzAInov2bbp2YMFEFA==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vidal-community/ng2-discovery",
-  "version": "2.0.1",
+  "version": "2.0.2-1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -18,14 +18,6 @@
   "types": "./index.d.ts",
   "main": "./index.js",
   "dependencies": {
-    "@angular/animations": "^6.1.7",
-    "@angular/common": "^6.1.7",
-    "@angular/core": "^6.1.7",
-    "@angular/forms": "^6.1.7",
-    "@angular/http": "^6.1.7",
-    "@angular/platform-browser": "^6.1.7",
-    "@angular/platform-browser-dynamic": "^6.1.7",
-    "@angular/router": "^6.1.7",
     "core-js": "^2.5.7",
     "rxjs": "^6.3.2",
     "rxjs-compat": "^6.3.2",
@@ -33,6 +25,14 @@
     "zone.js": "^0.8.26"
   },
   "devDependencies": {
+    "@angular/core": "^6.1.7",
+    "@angular/animations": "^6.1.7",
+    "@angular/common": "^6.1.7",
+    "@angular/forms": "^6.1.7",
+    "@angular/http": "^6.1.7",
+    "@angular/platform-browser": "^6.1.7",
+    "@angular/platform-browser-dynamic": "^6.1.7",
+    "@angular/router": "^6.1.7",
     "@angular-devkit/build-angular": "^0.8.1",
     "@angular-devkit/build-ng-packagr": "^0.8.1",
     "@angular/cli": "^6.2.1",
@@ -57,5 +57,15 @@
     "ts-node": "^1.2.1",
     "tslint": "^5.11.0",
     "typescript": "^2.7.2"
+  },
+  "peerDependencies": {
+    "@angular/core": "^6.1.7",
+    "@angular/animations": "^6.1.7",
+    "@angular/common": "^6.1.7",
+    "@angular/forms": "^6.1.7",
+    "@angular/http": "^6.1.7",
+    "@angular/platform-browser": "^6.1.7",
+    "@angular/platform-browser-dynamic": "^6.1.7",
+    "@angular/router": "^6.1.7"
   }
 }


### PR DESCRIPTION
In order to avoid conflict with angular version of application that use this lib.
ng2-discovery will now use @angular module from application node_modules.